### PR TITLE
Update s_switchport_mapping.py

### DIFF
--- a/s_switchport_mapping.py
+++ b/s_switchport_mapping.py
@@ -286,30 +286,28 @@ def get_arp_info(script):
     """
     A function that reads in the "show ip arp" CSV file that should be taken from the default gateway device for the
     switch being port mapped, so we can fill in the correct IP addresses for each device.
-
+    
     :param script: The script object that represents this script being executed
     :type script: scripts.Script
-
+    
     :return: A dictionary that can be used to lookup both the MAC and IP associated with an interface, or the IP and
         VLAN associated with a MAC address.
+        
     :rtype: dict
     """
-
     arp_filename = script.file_open_dialog("Please select the ARP file to use when looking up MAC addresses.", "Open",
-                                           "CSV Files (*.csv)|*.csv||")
+                                           "", "CSV Files (*.csv)|*.csv|All Files (*.*)|*.*||")
     if arp_filename == "":
         return {}
-
     with open(arp_filename, 'r') as arp_file:
         arp_csv = csv.reader(arp_file)
         arp_list = [x for x in arp_csv]
-
     arp_lookup = {}
     # Process all ARP entries AFTER the header row.
     for entry in arp_list[1:]:
         # Get the IP address
         ip = entry[0]
-        # Get the MAC address.  If 'Incomplete', skip entry
+        # Get the MAC address. If 'Incomplete', skip entry
         mac = entry[2]
         if mac.lower() == 'incomplete':
             continue
@@ -319,14 +317,11 @@ def get_arp_info(script):
             vlan = intf[4:]
         else:
             vlan = None
-
-        if intf in arp_lookup.keys():
+        if intf in list(arp_lookup.keys()):
             arp_lookup[intf].append((mac, ip))
         else:
             arp_lookup[intf] = [(mac, ip)]
-
         arp_lookup[(mac, vlan)] = ip
-
     return arp_lookup
 
 


### PR DESCRIPTION
Fix file open dialog in get_arp_info to properly apply CSV filter and target current directory.

The filter string was previously passed as default_filename, leading to invalid path resolution and no visible CSVs (dialog opened in fallback locations like system dirs). Inserted explicit empty default_filename and added 'All Files' option to filter for type selection flexibility.